### PR TITLE
Test example running the handler directly not as a sub-process

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/new.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/new.js
@@ -146,4 +146,6 @@ exports.handler = async function({
       ? `Created DAO: ${green(aragonId)} at ${green(ctx.daoAddress)}`
       : `Created DAO: ${green(ctx.daoAddress)}`
   )
+
+  return ctx.daoAddress
 }

--- a/packages/aragon-cli/test/dao/dao-new.test.js
+++ b/packages/aragon-cli/test/dao/dao-new.test.js
@@ -1,19 +1,40 @@
 import test from 'ava'
+import daoNew from '../../src/commands/dao_cmds/new'
+import { configCliMiddleware } from '../../src/middleware'
 import { runAragonCLI, normalizeOutput } from '../utils'
+import web3Utils from 'web3-utils'
 
-const daoAddressRegex = /Created DAO: (.*)$/
 const daoIdAndAddressAddressRegex = /Created DAO: (.*) at (.*)$/
 
+/**
+ * Simulates a yargs middleware run
+ * @param {T} args Command arguments
+ * @return {T} expanded args with middleware functions
+ */
+function middleware(args) {
+  args.reporter = { ...console, success: console.log }
+  return {
+    ...configCliMiddleware({ _: [], ...args }),
+    ...args,
+  }
+}
+
 test('creates a new DAO', async t => {
-  t.plan(2)
+  const args = {
+    debug: true,
+    apm: {
+      'ens-registry': '0x5f6f7e8cc7346a11ca2def8f827b7a0b612c56a1',
+    },
+    template: 'bare-template',
+    templateVersion: 'latest',
+    fnArgs: [],
+    fn: 'newInstance',
+    deployEvent: 'DeployDao',
+  }
 
-  const stdout = await runAragonCLI(['dao', 'new', '--debug'])
-  const daoAddress = stdout.match(daoAddressRegex)[1]
+  const daoAddress = await daoNew.handler(middleware(args))
 
-  const resultSnapshot = normalizeOutput(stdout).replace(daoAddress, '')
-
-  t.assert(/0x[a-fA-F0-9]{40}/.test(daoAddress), 'Invalid DAO address')
-  t.snapshot(resultSnapshot)
+  t.assert(web3Utils.isAddress(daoAddress), 'Invalid DAO address')
 })
 
 test.skip('assigns an Aragon Id with the "--aragon-id" param', async t => {


### PR DESCRIPTION
# 🦅 Pull Request

Example of how tests can be done without running a subprocess. This pattern has the advantages
- Coverage reporting
- Better debugging, stack traces
- Better atomicity which allows testing separately the argument parsing and processing from the handler itself
- Better assertions since the handler can return raw data instead of parsing an output
- Does not require the code to build before running
- Automatic type checking once with Typescript

```js
test('creates a new DAO', async t => {
  const args = {
    debug: true,
    apm: {
      'ens-registry': '0x5f6f7e8cc7346a11ca2def8f827b7a0b612c56a1',
    },
    template: 'bare-template',
    templateVersion: 'latest',
    fnArgs: [],
    fn: 'newInstance',
    deployEvent: 'DeployDao',
  }

  const daoAddress = await daoNew.handler(middleware(args))

  t.assert(web3Utils.isAddress(daoAddress), 'Invalid DAO address')
})
```

<!-- Please let us know why do you wish to include this change. 👇 -->

## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

## ✔️ PR Todo

- [ ] Include links to related issues/PRs
- [ ] Update unit tests for this change
- [ ] Update the relevant documentation
- [ ] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
